### PR TITLE
Add support for test.ts files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Quickly switch between Angular files for Vim. Inspired by [angular2-switcher](ht
 |`:NgSwitchTS` |  Open a TypeScript(.ts) file in the same component. If on ts file, open a previous file.
 |`:NgSwitchHTML` | Open a HTML(.html) file in the same component. If on html file, open a previous file.
 |`:NgSwitchCSS` | Open a stylesheet(.css/.scss/.sass/.stylus) file in the same component. If on stylesheet file, open a previous file.
-|`:NgSwitchSpec` | Open a spec (.spec.ts) file in the  same component. If on spec file, open a previous file.
+|`:NgSwitchSpec` | Open a spec (.spec.ts/.test.ts) file in the  same component. If on spec file, open a previous file.
 
 :bulb: `:SNgSwitchTS`, `:VNgSwitchTS`, etc. splits window horizontally or vertically.
 

--- a/autoload/ngswitcher/core.vim
+++ b/autoload/ngswitcher/core.vim
@@ -31,6 +31,7 @@ let s:ExtensionType = {
 \ 'ts': 'ts',
 \ 'html': 'html',
 \ 'spec.ts': 'spec',
+\ 'test.ts': 'spec',
 \ 'css': 'css',
 \ 'scss': 'css',
 \ 'sass': 'css',
@@ -69,6 +70,9 @@ let s:AngularFileFactory = {}
 function! s:AngularFileFactory.create(filePath) abort
   let ngFile = deepcopy(s:AngularFile)
   if a:filePath =~? '\.spec\.ts$'
+    let ngFile.name = fnamemodify(a:filePath, ':t:r:r')
+    let ngFile.extension = fnamemodify(a:filePath, ':e:e')
+  elseif a:filePath =~? '\.test\.ts$'
     let ngFile.name = fnamemodify(a:filePath, ':t:r:r')
     let ngFile.extension = fnamemodify(a:filePath, ':e:e')
   else

--- a/test/ngswitcher/core.vimspec
+++ b/test/ngswitcher/core.vimspec
@@ -19,6 +19,14 @@ Describe AngularFileFactory
     Assert Equals(ngFile.extension, 'spec.ts')
   End
 
+  It treats a spec file with .test.ts extension
+    let ngFile = factory.create('src/app/app.component.test.ts')
+    Assert Equals(ngFile.path, 'src/app/app.component.test.ts')
+    Assert Equals(ngFile.directory, 'src/app')
+    Assert Equals(ngFile.name, 'app.component')
+    Assert Equals(ngFile.extension, 'test.ts')
+  End
+
   Context when a file without extension is given
     It creates an object with a empty extension
       let ngFile = factory.create('./.gitignore')
@@ -91,6 +99,17 @@ Describe AngularFile
   Context .isSpec()
     It returns 1 if the file extension is .spec.ts (not *.ts)
       let spec = factory.create('foo.spec.ts')
+      Assert Equals(spec.isSpec(), 1)
+      let ts = factory.create('foo.ts')
+      Assert Equals(ts.isSpec(), 0)
+      let noExtension = factory.create('.gitignore')
+      Assert Equals(noExtension.isHTML(), 0)
+      let notDefined = factory.create('package.json')
+      Assert Equals(notDefined.isHTML(), 0)
+    End
+
+    It returns 1 if the file extension is .test.ts (not *.ts)
+      let spec = factory.create('foo.test.ts')
       Assert Equals(spec.isSpec(), 1)
       let ts = factory.create('foo.ts')
       Assert Equals(ts.isSpec(), 0)


### PR DESCRIPTION
Some Angular projects that I worked use test files with extension as "test.ts" instead of "spec.ts".

This PR allows this Switcher to recognize "test.ts" and "spec.ts" files likewise.
